### PR TITLE
Add typedoc integration CI

### DIFF
--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -38,9 +38,11 @@ jobs:
         run: |
           cd ~ && mkdir -p example/src && cd example
           yarn init -y
-          echo 'export class HelloWorld {}' >> src/hello-world.ts
           yarn add -D typedoc@${{ matrix.typedoc-version }}
+          yarn run tsc --init
+          echo 'export class HelloWorld {}' >> src/hello-world.ts
           yarn link typedoc-plugin-mermaid
-          yarn run typedoc --mode modules \
+          yarn run typedoc --mode file \
             --plugin typedoc-plugin-mermaid \
-            --out docs src
+            --out docs \
+            src

--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -17,7 +17,6 @@ jobs:
           - '~0.13.0'
           - '~0.12.0'
           - '~0.11.0'
-          - '~0.10.0'
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js
@@ -39,7 +38,7 @@ jobs:
           cd ~ && mkdir -p example/src && cd example
           yarn init -y
           yarn add -D typedoc@${{ matrix.typedoc-version }}
-          yarn run tsc --init
+          echo '{"compilerOptions": {"target": "es5","module": "commonjs","lib": ["es2015"],"strict": true,"esModuleInterop": true,"forceConsistentCasingInFileNames": true}}' >> tsconfig.json
           echo 'export class HelloWorld {}' >> src/hello-world.ts
           yarn link typedoc-plugin-mermaid
           yarn run typedoc --mode file \

--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -1,0 +1,43 @@
+name: Typedoc CI
+
+on: [push]
+
+jobs:
+  tests:
+    name: TypeDoc integration
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        typedoc-version:
+          - latest
+          - '~0.16.0'
+          - '~0.15.0'
+          - '~0.14.0'
+          - '~0.13.0'
+          - '~0.12.0'
+          - '~0.11.0'
+          - '~0.10.0'
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --ignore-optional
+        env:
+          CI: true
+      - name: Build
+        run: yarn build
+        env:
+          CI: true
+      - name: Link
+        run: yarn link
+      - name: TypeDoc integration test
+        run: |
+          mkdir example && cd example
+          yarn init -y
+          echo 'export class HelloWorld {}' >> hello-world.ts
+          yarn add -D typedoc@${{ matrix.typedoc-version }}
+          yarn link typedoc-plugin-mermaid
+          yarn run typedoc --plugin typedoc-plugin-mermaid

--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -35,11 +35,11 @@ jobs:
         run: yarn link
       - name: TypeDoc integration test
         run: |
-          mkdir -p example/src && cd example
+          cd ~ && mkdir -p example/src && cd example
           yarn init -y
           echo 'export class HelloWorld {}' >> src/hello-world.ts
           yarn add -D typedoc@${{ matrix.typedoc-version }}
           yarn link typedoc-plugin-mermaid
           yarn run typedoc --mode modules \
             --plugin typedoc-plugin-mermaid \
-            --out docs .
+            --out docs src

--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: TypeDoc integration
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: False
       matrix:
         typedoc-version:
           - latest

--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -35,9 +35,11 @@ jobs:
         run: yarn link
       - name: TypeDoc integration test
         run: |
-          mkdir example && cd example
+          mkdir -p example/src && cd example
           yarn init -y
-          echo 'export class HelloWorld {}' >> hello-world.ts
+          echo 'export class HelloWorld {}' >> src/hello-world.ts
           yarn add -D typedoc@${{ matrix.typedoc-version }}
           yarn link typedoc-plugin-mermaid
-          yarn run typedoc --plugin typedoc-plugin-mermaid
+          yarn run typedoc --mode modules \
+            --plugin typedoc-plugin-mermaid \
+            --out docs .


### PR DESCRIPTION
## What was a problem

- Documentation build fails due to version of TypeDoc.

## How this PR fixes the problem

Modified to notice that TypeDoc document generation failed by introducing CI.

## Check lists (check x in [ ] of list items)
- [ ] Test passed
- [ ] Coding style (indentation, etc)