### PR TITLE
feat: convert markdown mermaid code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "html-escaper": "^2.0.2"
+    "html-escaper": "^3.0.0"
   },
   "peerDependencies": {
     "typedoc": "^0.11.0"
   },
   "devDependencies": {
+    "@types/html-escaper": "^3.0.0",
     "@types/jest": "^24.0.9",
     "@types/node": "^13.7.0",
     "jest": "^24.3.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "build": "tsc -p ./src/tsconfig.json",
     "test": "jest"
   },
+  "dependencies": {
+    "html-escaper": "^2.0.2"
+  },
   "peerDependencies": {
     "typedoc": "^0.11.0"
   },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import * as html from 'html-escaper';
 import { Converter } from 'typedoc/dist/lib/converter';
 import { Component, ConverterComponent } from 'typedoc/dist/lib/converter/components';
@@ -139,9 +138,11 @@ export class MermaidPlugin extends ConverterComponent {
   public replaceMarkdownMermaidCodeBlocks(s: string) {
     let out = '';
     let i = 0;
-    let j = -1;
-    // tslint:disable-next-line: no-conditional-assignment
-    while ((j = s.indexOf(MermaidPlugin.markdownStartMermaid, i)) >= 0) {
+    for (
+      let j = s.indexOf(MermaidPlugin.markdownStartMermaid, i);
+      j >= 0;
+      j = s.indexOf(MermaidPlugin.markdownStartMermaid, i)
+    ) {
       const start = j + MermaidPlugin.markdownStartMermaid.length;
       const end = s.indexOf(MermaidPlugin.markdownEndMermaid, start);
       out += `${s.slice(i, j + 1)}<div class="mermaid">${html.escape(s.slice(start, end))}</div>`;

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -9,7 +9,8 @@ exports[`MermaidPlugin convert CommentTag 1`] = `
 exports[`MermaidPlugin convert Markdown snippet returns same value if body closing tag not exist 1`] = `
 "#### title
 
-<div class=\\"mermaid\\">graph</div>
+<div class=\\"mermaid\\">graph LR
+  &lt;a&gt; --&gt; &lt;b&gt;</div>
 
 more text"
 `;

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -6,6 +6,14 @@ exports[`MermaidPlugin convert CommentTag 1`] = `
  <div class=\\"mermaid\\">graph</div>"
 `;
 
+exports[`MermaidPlugin convert Markdown snippet returns same value if body closing tag not exist 1`] = `
+"#### title
+
+<div class=\\"mermaid\\">graph</div>
+
+more text"
+`;
+
 exports[`MermaidPlugin convert PageContents returns same value if body closing tag not exist 1`] = `"hoge"`;
 
 exports[`MermaidPlugin convert PageContents returns script tag for mermaid.js, initialize mermaid script, and body closing tag 1`] = `

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -34,10 +34,10 @@ describe('MermaidPlugin', () => {
   });
 
   it('convert Markdown snippet returns same value if body closing tag not exist', () => {
-    const input = '#### title\n\n```mermaid\ngraph\n```\n\nmore text';
+    const input = '#### title\n\n```mermaid\ngraph LR\n  <a> --> <b>\n```\n\nmore text';
     const result = plugin.replaceMarkdownMermaidCodeBlocks(input);
     expect(result).toMatch('#### title\n');
-    expect(result).toMatch('<div class="mermaid">graph</div>');
+    expect(result).toMatch('<div class="mermaid">graph LR\n  &lt;a&gt; --&gt; &lt;b&gt;</div>');
     expect(result).toMatch('\nmore text');
     expect(result).toMatchSnapshot();
   });

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -32,4 +32,13 @@ describe('MermaidPlugin', () => {
     expect(result).toEqual('hoge');
     expect(result).toMatchSnapshot();
   });
+
+  it('convert Markdown snippet returns same value if body closing tag not exist', () => {
+    const input = '#### title\n\n```mermaid\ngraph\n```\n\nmore text';
+    const result = plugin.replaceMarkdownMermaidCodeBlocks(input);
+    expect(result).toMatch('#### title\n');
+    expect(result).toMatch('<div class="mermaid">graph</div>');
+    expect(result).toMatch('\nmore text');
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,6 +1454,11 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-escaper@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,6 +326,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/html-escaper@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/html-escaper/-/html-escaper-3.0.0.tgz#97d7df443c0fc86e3abdd0971f4814a58e3ca762"
+  integrity sha512-OcJcvP3Yk8mjYwf/IdXZtTE1tb/u0WF0qa29ER07ZHCYUBZXSN29Z1mBS+/96+kNMGTFUAbSz9X+pHmHpZrTCw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1454,10 +1459,10 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-html-escaper@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
-  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+html-escaper@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.0.tgz#e4c85c7b599ea2f56436ca492ba5bab3ed76b3bf"
+  integrity sha512-69CofXDozHqdHDl1BZ3YiFp5rYN1qTwSXIVcBhVcZNkzj1vzx6Sko1nT58mzKip19DbKo8lHR9hf6/XeZ9+s3w==
 
 http-signature@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Basically, this makes mermaid diagrams in the README.md also get properly converted.