### PR TITLE
Reduce target to ES2019 for node12 compat

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2019",
     "moduleResolution": "node",
     "allowJs": false,
     "noImplicitAny": true,


### PR DESCRIPTION
Max target version for node 12 is ES2019, unless we want to have
separate tsconfig per node version, we need to target the lowest
common target.

This solves the testing error occuring under node 12.
