### PR TITLE
Update TypeDoc integration test to use entry point strategy expand

### DIFF
--- a/.github/workflows/typedoc-ci.yml
+++ b/.github/workflows/typedoc-ci.yml
@@ -38,4 +38,5 @@ jobs:
           yarn link typedoc-plugin-mermaid
           yarn run typedoc --plugin typedoc-plugin-mermaid \
             --out docs \
+            --entrypointStrategy expand \
             src


### PR DESCRIPTION
As TypeDoc 0.22.x has a different default entrypoint strategy we'll use
the old strategy explicily here.

Also update the version specified to ~0.22.0
