### PR TITLE
Added support for dark mode

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,15 +1,84 @@
 import * as html from 'html-escaper';
 import { Converter, Context, PageEvent, Application, ReflectionKind } from 'typedoc';
 
+const style = String.raw`
+<style>
+:root.mermaid-enabled .mermaid-block > pre {
+  display: none;
+}
+:root:not(.mermaid-enabled) .mermaid-block > .mermaid {
+  display: none !important;
+}
+
+.mermaid-block > .mermaid[data-done].dark {
+  display: var(--mermaid-dark-display);
+}
+.mermaid-block > .mermaid[data-done].light {
+  display: var(--mermaid-light-display);
+}
+
+:root {
+  --mermaid-dark-display: none;
+  --mermaid-light-display: block;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --mermaid-dark-display: none;
+    --mermaid-light-display: block;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mermaid-dark-display: block;
+    --mermaid-light-display: none;
+  }
+}
+body.light, :root[data-theme="light"] {
+  --mermaid-dark-display: none;
+  --mermaid-light-display: block;
+}
+body.dark, :root[data-theme="dark"] {
+  --mermaid-dark-display: block;
+  --mermaid-light-display: none;
+}
+</style>
+`;
+
 /**
  * 1. Load mermaid.js library.
  * 2. Initialize mermaid.
+ * 3. Add special attribute after SVG has been inserted.
  */
-const script =
-  '<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>' +
-  '<script>mermaid.initialize({startOnLoad:true});</script>';
+const script = String.raw`
+<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
+<script>
+(function() {
+  if (typeof mermaid === "undefined") {
+    return;
+  }
 
-const mermaidBlockStart = '<div class="mermaid">';
+  document.documentElement.classList.add("mermaid-enabled");
+
+  mermaid.initialize({startOnLoad:true});
+
+  requestAnimationFrame(function check() {
+    let some = false;
+    document.querySelectorAll("div.mermaid:not([data-done])").forEach(div => {
+      some = true;
+      if (div.querySelector("svg")) {
+        div.dataset.done = true;
+      }
+    });
+
+    if (some) {
+      requestAnimationFrame(check);
+    }
+  });
+})();
+</script>
+`;
+
+const mermaidBlockStart = '<div class="mermaid-block">';
 const mermaidBlockEnd = '</div>';
 
 export class MermaidPlugin {
@@ -64,7 +133,13 @@ export class MermaidPlugin {
    * Creates a mermaid block for the given mermaid code.
    */
   private toMermaidBlock(mermaidCode: string): string {
-    return mermaidBlockStart + html.escape(mermaidCode.trim()) + mermaidBlockEnd;
+    const htmlCode = html.escape(mermaidCode.trim());
+
+    const dark = `<div class="mermaid dark">%%{init:{"theme":"dark"}}%%\n${htmlCode}</div>`;
+    const light = `<div class="mermaid light">%%{init:{"theme":"default"}}%%\n${htmlCode}</div>`;
+    const pre = `<pre><code class="language-mermaid">${htmlCode}</code></pre>`;
+
+    return mermaidBlockStart + dark + light + pre + mermaidBlockEnd;
   }
 
   private onEndPage(event: PageEvent): void {
@@ -77,6 +152,10 @@ export class MermaidPlugin {
       // this page doesn't need to load mermaid
       return html;
     }
+
+    // find the closing </body> tag and insert our mermaid scripts
+    const headEndIndex = html.indexOf('</head>');
+    html = html.slice(0, headEndIndex) + style + html.slice(headEndIndex);
 
     // find the closing </body> tag and insert our mermaid scripts
     const bodyEndIndex = html.lastIndexOf('</body>');

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,10 +10,10 @@ const style = String.raw`
   display: none !important;
 }
 
-.mermaid-block > .mermaid[data-done].dark {
+.mermaid-block > .mermaid[data-inserted].dark {
   display: var(--mermaid-dark-display);
 }
-.mermaid-block > .mermaid[data-done].light {
+.mermaid-block > .mermaid[data-inserted].light {
   display: var(--mermaid-light-display);
 }
 
@@ -63,10 +63,10 @@ const script = String.raw`
 
   requestAnimationFrame(function check() {
     let some = false;
-    document.querySelectorAll("div.mermaid:not([data-done])").forEach(div => {
+    document.querySelectorAll("div.mermaid:not([data-inserted])").forEach(div => {
       some = true;
       if (div.querySelector("svg")) {
-        div.dataset.done = true;
+        div.dataset.inserted = true;
       }
     });
 

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -3,18 +3,94 @@
 exports[`MermaidPlugin convert CommentTag 1`] = `
 "#### title
 
-<div class=\\"mermaid\\">graph</div>"
+<div class=\\"mermaid-block\\"><div class=\\"mermaid dark\\">%%{init:{\\"theme\\":\\"dark\\"}}%%
+graph</div><div class=\\"mermaid light\\">%%{init:{\\"theme\\":\\"default\\"}}%%
+graph</div><pre><code class=\\"language-mermaid\\">graph</code></pre></div>"
 `;
 
 exports[`MermaidPlugin convert Markdown snippet returns same value if body closing tag not exist 1`] = `
 "#### title
 
-<div class=\\"mermaid\\">graph LR
-  &lt;a&gt; --&gt; &lt;b&gt;</div>
+<div class=\\"mermaid-block\\"><div class=\\"mermaid dark\\">%%{init:{\\"theme\\":\\"dark\\"}}%%
+graph LR
+  &lt;a&gt; --&gt; &lt;b&gt;</div><div class=\\"mermaid light\\">%%{init:{\\"theme\\":\\"default\\"}}%%
+graph LR
+  &lt;a&gt; --&gt; &lt;b&gt;</div><pre><code class=\\"language-mermaid\\">graph LR
+  &lt;a&gt; --&gt; &lt;b&gt;</code></pre></div>
 
 more text"
 `;
 
 exports[`MermaidPlugin convert PageContents returns same value if body closing tag not exist 1`] = `"hoge"`;
 
-exports[`MermaidPlugin convert PageContents returns script tag for mermaid.js, initialize mermaid script, and body closing tag 1`] = `"<div class=\\"mermaid\\"></div><script src=\\"https://unpkg.com/mermaid/dist/mermaid.min.js\\"></script><script>mermaid.initialize({startOnLoad:true});</script></body>"`;
+exports[`MermaidPlugin convert PageContents returns script tag for mermaid.js, initialize mermaid script, and body closing tag 1`] = `
+"<head>
+<style>
+:root.mermaid-enabled .mermaid-block > pre {
+  display: none;
+}
+:root:not(.mermaid-enabled) .mermaid-block > .mermaid {
+  display: none !important;
+}
+
+.mermaid-block > .mermaid[data-done].dark {
+  display: var(--mermaid-dark-display);
+}
+.mermaid-block > .mermaid[data-done].light {
+  display: var(--mermaid-light-display);
+}
+
+:root {
+  --mermaid-dark-display: none;
+  --mermaid-light-display: block;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --mermaid-dark-display: none;
+    --mermaid-light-display: block;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mermaid-dark-display: block;
+    --mermaid-light-display: none;
+  }
+}
+body.light, :root[data-theme=\\"light\\"] {
+  --mermaid-dark-display: none;
+  --mermaid-light-display: block;
+}
+body.dark, :root[data-theme=\\"dark\\"] {
+  --mermaid-dark-display: block;
+  --mermaid-light-display: none;
+}
+</style>
+</head><body><div class=\\"mermaid-block\\"></div>
+<script src=\\"https://unpkg.com/mermaid/dist/mermaid.min.js\\"></script>
+<script>
+(function() {
+  if (typeof mermaid === \\"undefined\\") {
+    return;
+  }
+
+  document.documentElement.classList.add(\\"mermaid-enabled\\");
+
+  mermaid.initialize({startOnLoad:true});
+
+  requestAnimationFrame(function check() {
+    let some = false;
+    document.querySelectorAll(\\"div.mermaid:not([data-done])\\").forEach(div => {
+      some = true;
+      if (div.querySelector(\\"svg\\")) {
+        div.dataset.done = true;
+      }
+    });
+
+    if (some) {
+      requestAnimationFrame(check);
+    }
+  });
+})();
+</script>
+</body>"
+`;

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -33,10 +33,10 @@ exports[`MermaidPlugin convert PageContents returns script tag for mermaid.js, i
   display: none !important;
 }
 
-.mermaid-block > .mermaid[data-done].dark {
+.mermaid-block > .mermaid[data-inserted].dark {
   display: var(--mermaid-dark-display);
 }
-.mermaid-block > .mermaid[data-done].light {
+.mermaid-block > .mermaid[data-inserted].light {
   display: var(--mermaid-light-display);
 }
 
@@ -79,10 +79,10 @@ body.dark, :root[data-theme=\\"dark\\"] {
 
   requestAnimationFrame(function check() {
     let some = false;
-    document.querySelectorAll(\\"div.mermaid:not([data-done])\\").forEach(div => {
+    document.querySelectorAll(\\"div.mermaid:not([data-inserted])\\").forEach(div => {
       some = true;
       if (div.querySelector(\\"svg\\")) {
-        div.dataset.done = true;
+        div.dataset.inserted = true;
       }
     });
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -7,12 +7,12 @@ describe('MermaidPlugin', () => {
     const input = 'title\ngraph';
     const result = plugin.handleMermaidTag(input);
     expect(result).toMatch('#### title');
-    expect(result).toMatch('<div class="mermaid">graph</div>');
+    expect(result).toMatch('class="mermaid');
     expect(result).toMatchSnapshot();
   });
 
   it('convert PageContents returns script tag for mermaid.js, initialize mermaid script, and body closing tag', () => {
-    const input = '<div class="mermaid"></div></body>';
+    const input = '<head></head><body><div class="mermaid-block"></div></body>';
     const result = plugin.insertMermaidScript(input);
     expect(result).toMatch('</body>');
     expect(result).toMatch('mermaid.initialize({');
@@ -31,7 +31,7 @@ describe('MermaidPlugin', () => {
     const input = '#### title\n\n```mermaid\ngraph LR\n  <a> --> <b>\n```\n\nmore text';
     const result = plugin.handleMermaidCodeBlocks(input);
     expect(result).toMatch('#### title\n');
-    expect(result).toMatch('<div class="mermaid">graph LR\n  &lt;a&gt; --&gt; &lt;b&gt;</div>');
+    expect(result).toMatch('graph LR\n  &lt;a&gt; --&gt; &lt;b&gt;');
     expect(result).toMatch('\nmore text');
     expect(result).toMatchSnapshot();
   });


### PR DESCRIPTION
This fixes #456.

The HTML this plugin generates is a little more complex now. We generate 3 variants of each graph now:

1. One dark theme variant.
2. One light theme variant.
3. One code block variant.

The code block is a fallback in case the mermaid library failed to load or JavaScript is disabled by the user.

CSS is used to only ever show one of the 3 variants.

### Some implementation details

- I used `body.light, :root[data-theme="light"]` to support 0.22.x (see TypeStrong/typedoc#1764) and the upcoming 0.23 (see TypeStrong/typedoc#1706).
- The whole code around `requestAnimationFrame` is necessary because mermaid.js adds the `data-processed="true"` attribute _before_ the SVG is inserted. This causes problems because we can only hide the wrong dark/light theme variant after its SVG has been inserted.

### Screenshots

<details>

Dark mode:

![image](https://user-images.githubusercontent.com/20878432/139539098-bc16be38-c77f-43bb-95cf-aadbea72438f.png)

Light mode:

![image](https://user-images.githubusercontent.com/20878432/139539123-079fbdf4-0c31-4382-a625-a94127975a60.png)

No JS:

![image](https://user-images.githubusercontent.com/20878432/139539136-16f3cf21-1836-4f54-9180-0af24a2999c5.png)

</details>
