### PR TITLE
Mermaid uses ESM modules now. Update so mermaid loads again.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,31 +51,26 @@ body.dark, :root[data-theme="dark"] {
  */
 function createScript(version: string): string {
   return String.raw`
-<script src="https://unpkg.com/mermaid@${version}/dist/mermaid.min.js"></script>
-<script>
-(function() {
-  if (typeof mermaid === "undefined") {
-    return;
-  }
+<script type="module">
+import mermaid from "https://unpkg.com/mermaid@${version}/dist/mermaid.esm.min.mjs";
 
-  document.documentElement.classList.add("mermaid-enabled");
+document.documentElement.classList.add("mermaid-enabled");
 
-  mermaid.initialize({startOnLoad:true});
+mermaid.initialize({startOnLoad:true});
 
-  requestAnimationFrame(function check() {
-    let some = false;
-    document.querySelectorAll("div.mermaid:not([data-inserted])").forEach(div => {
-      some = true;
-      if (div.querySelector("svg")) {
-        div.dataset.inserted = true;
-      }
-    });
-
-    if (some) {
-      requestAnimationFrame(check);
+requestAnimationFrame(function check() {
+  let some = false;
+  document.querySelectorAll("div.mermaid:not([data-inserted])").forEach(div => {
+    some = true;
+    if (div.querySelector("svg")) {
+      div.dataset.inserted = true;
     }
   });
-})();
+
+  if (some) {
+    requestAnimationFrame(check);
+  }
+});
 </script>
 `;
 }

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -66,31 +66,26 @@ body.dark, :root[data-theme=\\"dark\\"] {
 }
 </style>
 </head><body><div class=\\"mermaid-block\\"></div>
-<script src=\\"https://unpkg.com/mermaid@latest/dist/mermaid.min.js\\"></script>
-<script>
-(function() {
-  if (typeof mermaid === \\"undefined\\") {
-    return;
-  }
+<script type=\\"module\\">
+import mermaid from \\"https://unpkg.com/mermaid@latest/dist/mermaid.esm.min.mjs\\";
 
-  document.documentElement.classList.add(\\"mermaid-enabled\\");
+document.documentElement.classList.add(\\"mermaid-enabled\\");
 
-  mermaid.initialize({startOnLoad:true});
+mermaid.initialize({startOnLoad:true});
 
-  requestAnimationFrame(function check() {
-    let some = false;
-    document.querySelectorAll(\\"div.mermaid:not([data-inserted])\\").forEach(div => {
-      some = true;
-      if (div.querySelector(\\"svg\\")) {
-        div.dataset.inserted = true;
-      }
-    });
-
-    if (some) {
-      requestAnimationFrame(check);
+requestAnimationFrame(function check() {
+  let some = false;
+  document.querySelectorAll(\\"div.mermaid:not([data-inserted])\\").forEach(div => {
+    some = true;
+    if (div.querySelector(\\"svg\\")) {
+      div.dataset.inserted = true;
     }
   });
-})();
+
+  if (some) {
+    requestAnimationFrame(check);
+  }
+});
 </script>
 </body>"
 `;

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -19,7 +19,7 @@ describe('MermaidPlugin', () => {
     const result = plugin.insertMermaidScript(input);
     expect(result).toMatch('</body>');
     expect(result).toMatch('mermaid.initialize({');
-    expect(result).toMatch(/src="https:\/\/unpkg.com\/mermaid\@latest\/dist\/mermaid.min.js"/);
+    expect(result).toMatch(/import mermaid from "https:\/\/unpkg.com\/mermaid\@latest\/dist\/mermaid.esm.min.mjs";/);
     expect(result).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Since Mermaid has moved to ESM module, the former loading sequence no longer works.

This updates the code generation to use 'import'. The tests are updated and pass. It is deployed  (for now) on NPM as @rwk/typedoc-plugin-mermaid.