### PR TITLE
Add Dependabot setting for GitHub Actions

### DIFF
--- a/.changeset/afraid-pumas-wash.md
+++ b/.changeset/afraid-pumas-wash.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Add Dependabot setting for GitHub Actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,41 +3,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-    time: "20:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - 14.14.22
-    - 14.14.25
-    - 14.14.27
-    - 14.14.28
-    - 14.14.31
-    - 14.14.32
-    - 14.14.33
-    - 14.14.34
-    - 14.14.35
-    - 14.14.36
-    - 14.14.37
-    - 14.14.38
-    - 14.14.41
-    - 15.0.0
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-  - dependency-name: "@types/jest"
-    versions:
-    - 26.0.20
-    - 26.0.21
-    - 26.0.22
-  - dependency-name: typescript
-    versions:
-    - 4.1.3
-    - 4.1.4
-    - 4.1.5
-    - 4.2.2
-    - 4.2.3
-  - dependency-name: jquery
-    versions:
-    - 3.5.1
+    interval: "weekly"
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  schedule:
+    interval: 'weekly'


### PR DESCRIPTION
This pull request adds a Dependabot setting for GitHub Actions. The setting ensures that weekly updates are scheduled for the package ecosystem and directory specified. This will help keep the dependencies up to date and improve the overall security and stability of the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dependabot schedule for npm packages to weekly.
	- Introduced weekly Dependabot schedule for GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->