### PR TITLE
Add GitHub workflow to update copyright year in license file

### DIFF
--- a/.changeset/soft-singers-taste.md
+++ b/.changeset/soft-singers-taste.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Add GitHub workflow to update copyright year in license file

--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -1,0 +1,14 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: '0 3 1 1 *' # 03:00 AM on January 1
+  workflow_dispatch:
+jobs:
+  update-license-year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: FantasticFiasco/action-update-license-year@9135da8f9ccc675217e02357c744b6b541d45cb0 # 3.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a GitHub workflow that automatically updates the copyright year in the license file. The workflow runs on a schedule and also allows manual triggering. This ensures that the copyright year is always up to date without manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a scheduled GitHub Actions workflow to automatically update the copyright year in the license file.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->