### PR TITLE
Add Snapshot release workflows

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "snapshot": {
+    "prereleaseTemplate": "{tag}-{commit}",
+    "useCalculatedVersion": true
+  },
   "ignore": ["example"]
 }

--- a/.changeset/tame-flowers-pay.md
+++ b/.changeset/tame-flowers-pay.md
@@ -1,0 +1,15 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Add Snapshot release workflows
+
+- New Features
+  - Introduced snapshot release automation for pull requests using GitHub Actions.
+  - Added new GitHub Action to perform snapshot releases based on specific comments.
+  - Implemented a prerelease job in CI/CD workflow for automated next version releases.
+- Improvements
+  - Added new configuration options for snapshots to support pre-release templates and calculated versions.
+  - Improved GitHub Actions setup with an option to skip the checkout step for better performance.
+- Automation
+  - Enhanced workflow automation including permission checks, artifact handling, and snapshot release validation.

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,9 +1,17 @@
 name: Setup Action
 description: Composite Setup Action
+
+inputs:
+  skip-checkout:
+    description: Skip the checkout step
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - if: ${{ inputs.skip-checkout != 'true' }}
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:

--- a/.github/actions/snapshot-release/action.yaml
+++ b/.github/actions/snapshot-release/action.yaml
@@ -35,7 +35,7 @@ runs:
     run: |
       pnpm exec changeset version --snapshot ${{ inputs.name }}
       {
-        echo 'publish_result<<EOF' >>
+        echo 'publish_result<<EOF'
         pnpm exec changeset publish --no-git-tag --snapshot ${{ inputs.name }} --tag ${{ inputs.tag }}
         echo EOF
       } >> $GITHUB_OUTPUT

--- a/.github/actions/snapshot-release/action.yaml
+++ b/.github/actions/snapshot-release/action.yaml
@@ -7,6 +7,12 @@ inputs:
   tag:
     description: Tag name (e.g. next, dev, etc.)
     required: true
+  github-token:
+    description: GitHub token
+    required: true
+  npm-token:
+    description: NPM token
+    required: true
 
 outputs:
   publish_result:
@@ -22,7 +28,7 @@ runs:
         //registry.npmjs.org/:_authToken=$NPM_TOKEN
       EOF
     env:
-      NPM_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      NPM_TOKEN: ${{ inputs.npm-token }}
     shell: bash
   - name: "Snapshot Release @${{ inputs.tag }}"
     id: snapshot-release
@@ -34,5 +40,5 @@ runs:
         echo EOF
       } >> $GITHUB_OUTPUT
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ inputs.github-token }}
     shell: bash

--- a/.github/actions/snapshot-release/action.yaml
+++ b/.github/actions/snapshot-release/action.yaml
@@ -1,0 +1,38 @@
+name: Snapshot Release Action
+description: Composite Release Action
+inputs:
+  name:
+    description: Snapshot name (e.g. next, pr100, etc.)
+    required: true
+  tag:
+    description: Tag name (e.g. next, dev, etc.)
+    required: true
+
+outputs:
+  publish_result:
+    description: Publish result
+    value: ${{ steps.snapshot-release.outputs.publish_result }}
+
+runs:
+  using: composite
+  steps:
+  - name: Creating .npmrc
+    run: |
+      cat << EOF > "$HOME/.npmrc"
+        //registry.npmjs.org/:_authToken=$NPM_TOKEN
+      EOF
+    env:
+      NPM_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+    shell: bash
+  - name: "Snapshot Release @${{ inputs.tag }}"
+    id: snapshot-release
+    run: |
+      pnpm exec changeset version --snapshot ${{ inputs.name }}
+      {
+        echo 'publish_result<<EOF' >>
+        pnpm exec changeset publish --no-git-tag --snapshot ${{ inputs.name }} --tag ${{ inputs.tag }}
+        echo EOF
+      } >> $GITHUB_OUTPUT
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    shell: bash

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -115,3 +115,28 @@ jobs:
           NPM_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+
+  prerelease:
+    name: Prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs: release
+    # if repository is github.com/kamiazya/typedoc-plugin-mermaid
+    # and branch is main
+    # and release job dosen't publish package to npm
+    # then run this job
+    if: ${{ github.repository == 'kamiazya/typedoc-plugin-mermaid' && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.release.outputs.published == 'false' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Snapshot Release @next
+        uses: ./.github/actions/snapshot-release
+        with:
+          tag: next
+          name: next
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/pr-snapshot-release-command.yaml
+++ b/.github/workflows/pr-snapshot-release-command.yaml
@@ -103,7 +103,8 @@ jobs:
           if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
             git checkout origin/main -- .changeset
           fi
-      - uses: ./.github/actions/setup
+      - name: Setup without checkout
+        uses: ./.github/actions/setup
         with:
           skip-checkout: 'true'
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
@@ -114,6 +115,8 @@ jobs:
         with:
           name: pr${{ github.event.issue.number }}
           tag: develop
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/pr-snapshot-release-command.yaml
+++ b/.github/workflows/pr-snapshot-release-command.yaml
@@ -122,4 +122,9 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: ${{ steps.snapshot-release.outputs.succeeded == 'true' && 'rocket' || 'confused'}}
+          body: |
+            **Edited**:
+            Snapshot release @develop: ${{ steps.snapshot-release.outputs.publish_result && '✅' || '❌'}}
+            ```
+            ${{ steps.snapshot-release.outputs.publish_result }}
+            ```

--- a/.github/workflows/pr-snapshot-release-command.yaml
+++ b/.github/workflows/pr-snapshot-release-command.yaml
@@ -123,8 +123,8 @@ jobs:
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |
-            **Edited**:
-            Snapshot release @develop: ${{ steps.snapshot-release.outputs.publish_result && '✅' || '❌'}}
+            **Edited by GitHub Action[bot]**:
+
             ```
             ${{ steps.snapshot-release.outputs.publish_result }}
             ```

--- a/.github/workflows/pr-snapshot-release-command.yaml
+++ b/.github/workflows/pr-snapshot-release-command.yaml
@@ -1,0 +1,122 @@
+name: PullRequest Snapshot Release Command
+
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    if: github.event.sender.type == 'User' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/snapshot-release')
+    steps:
+      - name: Enforces that the actor permission is the Maintainer
+        uses: prince-chrismc/check-actor-permissions-action@d07d79a16495e5003e58112b596294d1a7c80f56 # v3.0.0
+        with:
+          permission: write
+
+      - name: Add initial reaction
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
+  # Build the package and upload it as an artifact
+  build:
+    name: Build
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Build
+        run: pnpm build
+        env:
+          CI: true
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: dist
+          path: dist
+
+  snapshot:
+    name: Snapshot Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Validate pull request
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: pr_data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            try {
+              const pullRequest = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              })
+
+              // Pull request from fork
+              if (context.payload.repository.full_name !== pullRequest.data.head.repo.full_name) {
+                const errorMessage = '`/snapshot-release` is not supported on pull requests from forked repositories.'
+
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: errorMessage,
+                })
+
+                core.setFailed(errorMessage)
+              }
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - name: Checkout default branch
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Checkout pull request branch
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reset changeset entries on changeset-release/main branch
+        run: |
+          if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
+            git checkout origin/main -- .changeset
+          fi
+      - uses: ./.github/actions/setup
+        with:
+          skip-checkout: 'true'
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+
+      - name: Snapshot Release @ develop
+        id: snapshot-release
+        uses: ./.github/actions/snapshot-release
+        with:
+          name: pr${{ github.event.issue.number }}
+          tag: develop
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: ${{ steps.snapshot-release.outputs.succeeded == 'true' && 'rocket' || 'confused'}}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions setup, specifically adding an optional skip-checkout input. It also introduces a new Snapshot Release Action that allows for creating and publishing snapshot releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced snapshot release workflows for pull requests using GitHub Actions, enhancing automation for version releases.
  - Added a GitHub Actions workflow for creating snapshot releases triggered by specific comments on pull requests.

- **Chores**
  - Added configuration for prerelease templates and calculated versions.
  - Added parameters and conditions to control the checkout step in the setup action.
  - Defined inputs, outputs, and steps for a composite snapshot release action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->