### PR TITLE
Add artifact attestation step to CI/CD workflows

### DIFF
--- a/.changeset/selfish-items-kick.md
+++ b/.changeset/selfish-items-kick.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Add artifact attestation step to CI/CD workflows

--- a/.github/actions/snapshot-release/action.yaml
+++ b/.github/actions/snapshot-release/action.yaml
@@ -42,3 +42,8 @@ runs:
     env:
       GITHUB_TOKEN: ${{ inputs.github-token }}
     shell: bash
+
+  - name: Generate artifact attestation
+    uses: actions/attest-build-provenance@49df96e17e918a15956db358890b08e61c704919 # v1.2.0
+    with:
+      subject-path: ${{ github.workspace }}/dist

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -97,6 +97,7 @@ jobs:
       contents: write # Used to commit to "Version Packages" PR
       pull-requests: write # Used to create "Version Packages" PR
       id-token: write # Used to publish to npm with provenance statements
+      attestations: write # Used to generate provenance attestation
       # Other permissions are defaulted to none
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,6 +113,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Generate artifact attestation
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        uses: actions/attest-build-provenance@49df96e17e918a15956db358890b08e61c704919 # v1.2.0
+        with:
+          subject-path: ${{ github.workspace }}/dist
     outputs:
       published: ${{ steps.changesets.outputs.published }}
 

--- a/.github/workflows/pr-snapshot-release-command.yaml
+++ b/.github/workflows/pr-snapshot-release-command.yaml
@@ -57,6 +57,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      attestations: write
       id-token: write
     steps:
       - name: Validate pull request


### PR DESCRIPTION
This pull request adds an artifact attestation step to the CI/CD workflows. The attestation step generates a provenance for the artifacts in the `dist` directory. This ensures that the artifacts can be verified and trusted.