### PR TITLE
Fix to download before publish

### DIFF
--- a/.changeset/shaggy-jobs-sip.md
+++ b/.changeset/shaggy-jobs-sip.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Fix to download before publish

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -103,6 +103,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Setup
         uses: ./.github/actions/setup
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1.4.7


### PR DESCRIPTION
This pull request includes a fix to the download process before publishing. The issue was resolved by adding the necessary step to download the artifact before proceeding with the publishing process.