### PR TITLE
Add integration test

### DIFF
--- a/.changeset/proud-foxes-destroy.md
+++ b/.changeset/proud-foxes-destroy.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-mermaid": patch
+---
+
+Add integration test

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -82,6 +82,33 @@ jobs:
         env:
           CI: true
 
+  integration_test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: False
+      matrix:
+        typedoc-version:
+          - '^0.23.x'
+          - '^0.24.x'
+          - '^0.25.x'
+          - '^0.26.x'
+    needs:
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Setup
+        uses: ./.github/actions/setup
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      - name: TypeDoc integration test
+        working-directory: example
+        run: |
+          pnpm add -D typedoc@${{ matrix.typedoc-version }}
+          pnpm doc
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -61,8 +61,8 @@ jobs:
         with:
           name: dist
           path: dist
-  test:
-    name: Test on node ${{ matrix.node-version }}
+  unit_test:
+    name: Unit Test on node ${{ matrix.node-version }}
     needs:
       - check_format
       - check_type
@@ -83,7 +83,7 @@ jobs:
           CI: true
 
   integration_test:
-    name: Integration Test
+    name: Integration Test on TypeDoc ${{ matrix.typedoc-version }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -114,12 +114,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - test
+      - unit_test
+      - integration_test
     # if repository is github.com/kamiazya/typedoc-plugin-mermaid
     # and branch is main
     # and before job is successful
     # then run this job
-    if: ${{ github.repository == 'kamiazya/typedoc-plugin-mermaid' && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.build.result == 'success' && needs.test.result == 'success' }}
+    if: ${{ github.repository == 'kamiazya/typedoc-plugin-mermaid' && github.ref == 'refs/heads/main' && github.event_name == 'push' && success() }}
     permissions:
       contents: write # Used to commit to "Version Packages" PR
       pull-requests: write # Used to create "Version Packages" PR

--- a/example/package.json
+++ b/example/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "typedoc": "^0.26.3",
-    "typedoc-plugin-mermaid": "workspace:*"
+    "typedoc-plugin-mermaid": "workspace:*",
+    "typescript": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       typedoc-plugin-mermaid:
         specifier: workspace:*
         version: link:..
+      typescript:
+        specifier: '*'
+        version: 5.4.5
 
 packages:
 


### PR DESCRIPTION
This pull request adds an integration test to the project. The integration test is designed to test the functionality of the TypeDoc plugin with different versions of TypeDoc. The test is run as part of the CI/CD pipeline and helps ensure the stability and compatibility of the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added integration test job to the CI workflow to ensure compatibility with different versions of TypeDoc.
- **Refactor**
  - Renamed `test` job to `unit_test` in the CI workflow for clarity.
- **Chores**
  - Updated `devDependencies` in `example/package.json` to include TypeScript.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->